### PR TITLE
Land-able terrain

### DIFF
--- a/asteroids.js
+++ b/asteroids.js
@@ -2,6 +2,7 @@ import {
   randomBool,
   randomBetween,
   simpleBallisticUpdate,
+  isAboveTerrain,
 } from "./helpers/helpers.js";
 import { makeExplosion } from "./lander/explosion.js";
 import { LANDER_WIDTH, LANDER_HEIGHT } from "./helpers/constants.js";
@@ -12,7 +13,6 @@ export const launchAsteroid = (state, getLanderPosition, onLanderCollision) => {
   const canvasHeight = state.get("canvasHeight");
   const _size = randomBetween(12, 30);
   const _rotationDirection = randomBool();
-  const _groundedHeight = canvasHeight - _size + _size / 2;
   const _leftOfScreen = randomBool();
 
   let _position = {
@@ -28,15 +28,22 @@ export const launchAsteroid = (state, getLanderPosition, onLanderCollision) => {
   let _impact = false;
 
   const draw = () => {
-    if (!_impact && _position.y < _groundedHeight) {
+    if (
+      !_impact &&
+      isAboveTerrain(
+        CTX,
+        _position,
+        state.get("terrain"),
+        state.get("scaleFactor")
+      )
+    ) {
       [_position, _velocity, _rotationVelocity, _angle] = simpleBallisticUpdate(
+        state,
         _position,
         _velocity,
         _angle,
-        _groundedHeight,
         _rotationDirection,
-        _rotationVelocity,
-        canvasWidth
+        _rotationVelocity
       );
 
       const landerPosition = getLanderPosition();

--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -117,9 +117,9 @@ export const simpleBallisticUpdate = (
   return [newPosition, newVelocity, newRotationVelocity, newAngle];
 };
 
-export const shuffleArray = (array) => {
+export const seededShuffleArray = (array, seededRandom) => {
   for (let i = array.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
+    const j = Math.floor(seededRandom.getSeededRandom() * (i + 1));
     const temp = array[i];
     array[i] = array[j];
     array[j] = temp;

--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -116,3 +116,12 @@ export const simpleBallisticUpdate = (
 
   return [newPosition, newVelocity, newRotationVelocity, newAngle];
 };
+
+export const shuffleArray = (array) => {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const temp = array[i];
+    array[i] = array[j];
+    array[j] = temp;
+  }
+};

--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -14,7 +14,7 @@ export const generateCanvas = ({ width, height, attachNode }) => {
 
   document.querySelector(attachNode).appendChild(element);
 
-  return [context, width, height, element];
+  return [context, width, height, element, scale];
 };
 
 export const animate = (drawFunc) => {

--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -79,27 +79,46 @@ export const progress = (start, end, current) =>
 export const percentProgress = (start, end, current) =>
   Math.max(0, Math.min(((current - start) / (end - start)) * 100, 100));
 
+export const isAboveTerrain = (CTX, position, terrain, scaleFactor) => {
+  const terrainLandingData = terrain.getLandingData();
+
+  return (
+    position.y < terrainLandingData.terrainHeight ||
+    (position.y >= terrainLandingData.terrainHeight &&
+      !CTX.isPointInPath(
+        terrainLandingData.terrainPath2D,
+        position.x * scaleFactor,
+        position.y * scaleFactor
+      ))
+  );
+};
+
 export const simpleBallisticUpdate = (
+  state,
   currentPosition,
   currentVelocity,
   currentAngle,
-  groundedHeight,
   rotationDirection,
-  currentRotationVelocity,
-  canvasWidth
+  currentRotationVelocity
 ) => {
+  const CTX = state.get("CTX");
+  const canvasWidth = state.get("canvasWidth");
   const newPosition = { ...currentPosition };
   const newVelocity = { ...currentVelocity };
   let newRotationVelocity;
   let newAngle = currentAngle;
 
-  newPosition.y = Math.min(
-    currentPosition.y + currentVelocity.y,
-    groundedHeight + 1
-  );
+  newPosition.y = currentPosition.y + currentVelocity.y;
   newPosition.x = currentPosition.x + currentVelocity.x;
 
-  if (newPosition.y <= groundedHeight) {
+  if (
+    isAboveTerrain(
+      CTX,
+      newPosition,
+      state.get("terrain"),
+      state.get("scaleFactor")
+    )
+  ) {
     newRotationVelocity = rotationDirection
       ? currentRotationVelocity + randomBetween(0, 0.01)
       : currentRotationVelocity - randomBetween(0, 0.01);

--- a/index.js
+++ b/index.js
@@ -43,6 +43,8 @@ const appState = makeStateManager()
   .set("challengeManager", challengeManager)
   .set("seededRandom", seededRandom);
 
+const stars = makeStarfield(appState);
+const terrain = makeTerrain(appState);
 const instructions = manageInstructions(onCloseInstructions);
 const toyLander = makeToyLander(
   appState,
@@ -52,11 +54,15 @@ const toyLander = makeToyLander(
   () => instructions.setEngineAndRotationDone()
 );
 const toyLanderControls = makeControls(appState, toyLander, audioManager);
-const lander = makeLander(appState, onGameEnd, onResetXPos);
+const lander = makeLander(
+  appState,
+  terrain.getLandingData,
+  onGameEnd,
+  onResetXPos
+);
 const landerControls = makeControls(appState, lander, audioManager);
-const stars = makeStarfield(appState);
-const terrain = makeTerrain(appState);
 const tally = makeTallyManger();
+
 let sendAsteroid = randomBool();
 let asteroidCountdown = randomBetween(2000, 15000);
 let asteroids = [];

--- a/index.js
+++ b/index.js
@@ -22,11 +22,12 @@ import { makeSeededRandom } from "../helpers/seededrandom.js";
 // SETUP
 
 const audioManager = makeAudioManager();
-const [CTX, canvasWidth, canvasHeight, canvasElement] = generateCanvas({
-  width: window.innerWidth,
-  height: window.innerHeight,
-  attachNode: ".game",
-});
+const [CTX, canvasWidth, canvasHeight, canvasElement, scaleFactor] =
+  generateCanvas({
+    width: window.innerWidth,
+    height: window.innerHeight,
+    attachNode: ".game",
+  });
 const challengeManager = makeChallengeManager();
 const seededRandom = makeSeededRandom();
 
@@ -39,12 +40,15 @@ const appState = makeStateManager()
   .set("canvasWidth", canvasWidth)
   .set("canvasHeight", canvasHeight)
   .set("canvasElement", canvasElement)
+  .set("scaleFactor", scaleFactor)
   .set("audioManager", audioManager)
   .set("challengeManager", challengeManager)
   .set("seededRandom", seededRandom);
 
-const stars = makeStarfield(appState);
 const terrain = makeTerrain(appState);
+appState.set("terrain", terrain);
+
+const stars = makeStarfield(appState);
 const instructions = manageInstructions(onCloseInstructions);
 const toyLander = makeToyLander(
   appState,
@@ -54,12 +58,7 @@ const toyLander = makeToyLander(
   () => instructions.setEngineAndRotationDone()
 );
 const toyLanderControls = makeControls(appState, toyLander, audioManager);
-const lander = makeLander(
-  appState,
-  terrain.getLandingData,
-  onGameEnd,
-  onResetXPos
-);
+const lander = makeLander(appState, onGameEnd, onResetXPos);
 const landerControls = makeControls(appState, lander, audioManager);
 const tally = makeTallyManger();
 

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ import { makeConfetti } from "./lander/confetti.js";
 import { makeTallyManger } from "./tally.js";
 import { launchAsteroid } from "./asteroids.js";
 import { makeChallengeManager } from "./challenge.js";
+import { makeSeededRandom } from "../helpers/seededrandom.js";
 
 // SETUP
 
@@ -27,6 +28,11 @@ const [CTX, canvasWidth, canvasHeight, canvasElement] = generateCanvas({
   attachNode: ".game",
 });
 const challengeManager = makeChallengeManager();
+const seededRandom = makeSeededRandom();
+
+challengeManager.isChallengeOn()
+  ? seededRandom.setDailyChallengeSeed()
+  : seededRandom.setRandomSeed();
 
 const appState = makeStateManager()
   .set("CTX", CTX)
@@ -34,7 +40,8 @@ const appState = makeStateManager()
   .set("canvasHeight", canvasHeight)
   .set("canvasElement", canvasElement)
   .set("audioManager", audioManager)
-  .set("challengeManager", challengeManager);
+  .set("challengeManager", challengeManager)
+  .set("seededRandom", seededRandom);
 
 const instructions = manageInstructions(onCloseInstructions);
 const toyLander = makeToyLander(
@@ -131,15 +138,23 @@ function onGameEnd(data) {
 }
 
 function onResetGame() {
+  challengeManager.isChallengeOn()
+    ? seededRandom.setDailyChallengeSeed()
+    : seededRandom.setRandomSeed();
+
   randomConfetti = [];
   asteroids = [];
   sendAsteroid = randomBool();
   asteroidCountdown = randomBetween(2000, 15000);
+  stars.reGenerate();
+  terrain.reGenerate();
 }
 
 function onResetXPos() {
-  stars.reGenerate();
-  terrain.reGenerate();
+  if (!challengeManager.isChallengeOn()) {
+    stars.reGenerate();
+    terrain.reGenerate();
+  }
 }
 
 function onAsteroidImpact(asteroidVelocity) {

--- a/lander/confetti.js
+++ b/lander/confetti.js
@@ -38,7 +38,6 @@ export const makeConfetti = (state, amount, passedPosition, passedVelocity) => {
   const _makeConfettiPiece = (position, velocity) => {
     const _size = randomBetween(1, 6);
     const _rotationDirection = randomBool();
-    const _groundedHeight = canvasHeight - _size + _size / 2;
     const _color = `hsl(${randomBetween(0, 360)}, 100%, 50%)`;
 
     let _position = { ...position };
@@ -51,13 +50,12 @@ export const makeConfetti = (state, amount, passedPosition, passedVelocity) => {
 
     const draw = () => {
       [_position, _velocity, _rotationVelocity, _angle] = simpleBallisticUpdate(
+        state,
         _position,
         _velocity,
         _angle,
-        _groundedHeight,
         _rotationDirection,
-        _rotationVelocity,
-        canvasWidth
+        _rotationVelocity
       );
 
       CTX.save();
@@ -73,7 +71,6 @@ export const makeConfetti = (state, amount, passedPosition, passedVelocity) => {
 
   const _makeTwirlPiece = (position, velocity) => {
     const _size = randomBetween(4, 8);
-    const _groundedHeight = canvasHeight - _size + _size / 2;
     const _color = `hsl(${randomBetween(0, 360)}, 100%, 50%)`;
     const _rotationDirection = randomBool();
 
@@ -93,13 +90,12 @@ export const makeConfetti = (state, amount, passedPosition, passedVelocity) => {
 
     const draw = () => {
       [_position, _velocity, _rotationVelocity] = simpleBallisticUpdate(
+        state,
         _position,
         _velocity,
         0,
-        _groundedHeight,
         _rotationDirection,
-        _rotationVelocity,
-        canvasWidth
+        _rotationVelocity
       );
 
       const width =

--- a/lander/explosion.js
+++ b/lander/explosion.js
@@ -15,14 +15,11 @@ export const makeExplosion = (
   amount
 ) => {
   const CTX = state.get("CTX");
-  const canvasWidth = state.get("canvasWidth");
-  const canvasHeight = state.get("canvasHeight");
 
   const _makeRandomExplosionPiece = (position, velocity) => {
     const _width = randomBetween(size / 4, size);
     const _height = randomBetween(size / 4, size);
     const _rotationDirection = randomBool();
-    const _groundedHeight = canvasHeight - _height + _height / 2;
 
     let _position = { ...position };
     let _velocity = {
@@ -34,13 +31,12 @@ export const makeExplosion = (
 
     const draw = () => {
       [_position, _velocity, _rotationVelocity, _angle] = simpleBallisticUpdate(
+        state,
         _position,
         _velocity,
         _angle,
-        _groundedHeight,
         _rotationDirection,
-        _rotationVelocity,
-        canvasWidth
+        _rotationVelocity
       );
 
       CTX.save();
@@ -67,13 +63,10 @@ export const makeExplosion = (
 
 export const makeLanderExplosion = (state, position, velocity, angle) => {
   const CTX = state.get("CTX");
-  const canvasWidth = state.get("canvasWidth");
-  const canvasHeight = state.get("canvasHeight");
 
   const _makeLanderChunk = (drawInstructions, yOffset) => {
     const _rotationDirection = randomBool();
     const _height = LANDER_HEIGHT / 3 + yOffset;
-    const _groundedHeight = canvasHeight - _height + _height / 2;
 
     let _position = { ...position };
     let _velocity = { ...velocity };
@@ -82,13 +75,12 @@ export const makeLanderExplosion = (state, position, velocity, angle) => {
 
     const draw = () => {
       [_position, _velocity, _rotationVelocity, _angle] = simpleBallisticUpdate(
+        state,
         _position,
         _velocity,
         _angle,
-        _groundedHeight,
         _rotationDirection,
-        _rotationVelocity,
-        canvasWidth
+        _rotationVelocity
       );
 
       // In order to render three separate pieces in the same location as the

--- a/lander/lander.js
+++ b/lander/lander.js
@@ -250,10 +250,20 @@ export const makeLander = (state, onGameEnd, onResetXPos) => {
         _babySoundPlayed = false;
       }
     } else if (!_gameEndData) {
-      _setGameEndData(
+      const inLandingArea = state
+        .get("terrain")
+        .getLandingData()
+        .landingSurfaces.some(
+          ({ x, width }) =>
+            _position.x - LANDER_WIDTH / 2 >= x &&
+            _position.x + LANDER_WIDTH / 2 <= x + width
+        );
+      const didLand =
         getVectorVelocity(_velocity) < CRASH_VELOCITY &&
-          getAngleDeltaUpright(_angle) < CRASH_ANGLE
-      );
+        getAngleDeltaUpright(_angle) < CRASH_ANGLE &&
+        inLandingArea;
+
+      _setGameEndData(didLand);
     }
   };
 

--- a/lander/lander.js
+++ b/lander/lander.js
@@ -27,7 +27,7 @@ import { makeConfetti } from "./confetti.js";
 import { drawTrajectory } from "./trajectory.js";
 import { drawLanderGradient } from "./gradient.js";
 
-export const makeLander = (state, onGameEnd, onResetXPos) => {
+export const makeLander = (state, getLandingData, onGameEnd, onResetXPos) => {
   const CTX = state.get("CTX");
   const canvasWidth = state.get("canvasWidth");
   const canvasHeight = state.get("canvasHeight");
@@ -169,9 +169,10 @@ export const makeLander = (state, onGameEnd, onResetXPos) => {
 
   const _updateProps = () => {
     _position.y = Math.min(_position.y + _velocity.y, _groundedHeight);
+    const aboveGround = _position.y < _groundedHeight;
 
     // Is above ground
-    if (_position.y < _groundedHeight) {
+    if (aboveGround) {
       // Update ballistic properties
       if (_rotatingRight) _rotationVelocity += 0.01;
       if (_rotatingLeft) _rotationVelocity -= 0.01;

--- a/lander/lander.js
+++ b/lander/lander.js
@@ -8,6 +8,7 @@ import {
   getAngleDeltaUprightWithSign,
   heightInFeet,
   percentProgress,
+  isAboveTerrain,
 } from "../helpers/helpers.js";
 import {
   scoreLanding,
@@ -30,12 +31,12 @@ import { drawLanderGradient } from "./gradient.js";
 export const makeLander = (state, onGameEnd, onResetXPos) => {
   const CTX = state.get("CTX");
   const canvasWidth = state.get("canvasWidth");
-  const scaleFactor = state.get("scaleFactor");
-  const terrainLandingData = state.get("terrain").getLandingData();
 
   // Use grounded height to approximate distance from ground
   const _groundedHeight =
-    terrainLandingData.terrainMinHeight - LANDER_HEIGHT + LANDER_HEIGHT / 2;
+    state.get("terrain").getLandingData().terrainMinHeight -
+    LANDER_HEIGHT +
+    LANDER_HEIGHT / 2;
   const _thrust = 0.01;
 
   let _position;
@@ -171,23 +172,16 @@ export const makeLander = (state, onGameEnd, onResetXPos) => {
   };
 
   const _updateProps = () => {
-    _position.y = Math.min(_position.y + _velocity.y, _groundedHeight);
+    _position.y = _position.y + _velocity.y;
 
-    const aboveGround =
-      _position.y < terrainLandingData.terrainHeight ||
-      (_position.y >= terrainLandingData.terrainHeight &&
-        !CTX.isPointInPath(
-          terrainLandingData.terrainPath2D,
-          _position.x * scaleFactor,
-          (_position.y + LANDER_HEIGHT / 2) * scaleFactor
-        ));
-
-    // Debug square
-    CTX.fillStyle = "red";
-    CTX.fillRect(_position.x, _position.y + LANDER_HEIGHT / 2, 4, 4);
-
-    // Is above ground
-    if (aboveGround) {
+    if (
+      isAboveTerrain(
+        CTX,
+        { x: _position.x, y: _position.y + LANDER_HEIGHT / 2 },
+        state.get("terrain"),
+        state.get("scaleFactor")
+      )
+    ) {
       // Update ballistic properties
       if (_rotatingRight) _rotationVelocity += 0.01;
       if (_rotatingLeft) _rotationVelocity -= 0.01;

--- a/lander/lander.js
+++ b/lander/lander.js
@@ -30,10 +30,13 @@ import { drawLanderGradient } from "./gradient.js";
 export const makeLander = (state, onGameEnd, onResetXPos) => {
   const CTX = state.get("CTX");
   const canvasWidth = state.get("canvasWidth");
-  const canvasHeight = state.get("canvasHeight");
+  const scaleFactor = state.get("scaleFactor");
+  const terrainLandingData = state.get("terrain").getLandingData();
 
+  // Use grounded height to approximate distance from ground
+  const _groundedHeight =
+    terrainLandingData.terrainMinHeight - LANDER_HEIGHT + LANDER_HEIGHT / 2;
   const _thrust = 0.01;
-  const _groundedHeight = canvasHeight - LANDER_HEIGHT + LANDER_HEIGHT / 2;
 
   let _position;
   let _velocity;
@@ -169,7 +172,19 @@ export const makeLander = (state, onGameEnd, onResetXPos) => {
 
   const _updateProps = () => {
     _position.y = Math.min(_position.y + _velocity.y, _groundedHeight);
-    const aboveGround = _position.y < _groundedHeight;
+
+    const aboveGround =
+      _position.y < terrainLandingData.terrainHeight ||
+      (_position.y >= terrainLandingData.terrainHeight &&
+        !CTX.isPointInPath(
+          terrainLandingData.terrainPath2D,
+          _position.x * scaleFactor,
+          (_position.y + LANDER_HEIGHT / 2) * scaleFactor
+        ));
+
+    // Debug square
+    CTX.fillStyle = "red";
+    CTX.fillRect(_position.x, _position.y + LANDER_HEIGHT / 2, 4, 4);
 
     // Is above ground
     if (aboveGround) {

--- a/lander/lander.js
+++ b/lander/lander.js
@@ -26,9 +26,6 @@ import {
   CRASH_ANGLE,
 } from "../helpers/constants.js";
 import { drawLanderGradient } from "./gradient.js";
-import { makeSeededRandom } from "../helpers/seededrandom.js";
-
-const seededRandom = makeSeededRandom();
 
 export const makeLander = (state, onGameEnd, onResetXPos) => {
   const CTX = state.get("CTX");
@@ -60,10 +57,8 @@ export const makeLander = (state, onGameEnd, onResetXPos) => {
   let _boostersUsedPreviousFrame;
   let _babySoundPlayed;
 
-  const resetProps = ({ challenge }) => {
-    challenge
-      ? seededRandom.setDailyChallengeSeed()
-      : seededRandom.setRandomSeed();
+  const resetProps = () => {
+    const seededRandom = state.get("seededRandom");
 
     _position = {
       x: seededRandomBetween(
@@ -101,7 +96,7 @@ export const makeLander = (state, onGameEnd, onResetXPos) => {
     _boostersUsedPreviousFrame = false;
     _babySoundPlayed = false;
   };
-  resetProps({ challenge: true });
+  resetProps();
 
   const _setGameEndData = (landed) => {
     _gameEndData = {

--- a/lander/lander.js
+++ b/lander/lander.js
@@ -27,7 +27,7 @@ import { makeConfetti } from "./confetti.js";
 import { drawTrajectory } from "./trajectory.js";
 import { drawLanderGradient } from "./gradient.js";
 
-export const makeLander = (state, getLandingData, onGameEnd, onResetXPos) => {
+export const makeLander = (state, onGameEnd, onResetXPos) => {
   const CTX = state.get("CTX");
   const canvasWidth = state.get("canvasWidth");
   const canvasHeight = state.get("canvasHeight");
@@ -421,14 +421,7 @@ export const makeLander = (state, getLandingData, onGameEnd, onResetXPos) => {
     _updateProps();
 
     if (!_engineOn && !_rotatingLeft && !_rotatingRight) {
-      drawTrajectory(
-        state,
-        _position,
-        _angle,
-        _velocity,
-        _rotationVelocity,
-        _groundedHeight
-      );
+      drawTrajectory(state, _position, _angle, _velocity, _rotationVelocity);
     }
 
     if (_flipConfetti.length > 0) _flipConfetti.forEach((c) => c.draw());

--- a/lander/lander.js
+++ b/lander/lander.js
@@ -1,5 +1,3 @@
-import { makeLanderExplosion } from "./explosion.js";
-import { makeConfetti } from "./confetti.js";
 import {
   randomBetween,
   seededRandomBetween,
@@ -17,7 +15,6 @@ import {
   landingScoreDescription,
   crashScoreDescription,
 } from "../helpers/scoring.js";
-import { drawTrajectory } from "./trajectory.js";
 import {
   GRAVITY,
   LANDER_WIDTH,
@@ -25,6 +22,9 @@ import {
   CRASH_VELOCITY,
   CRASH_ANGLE,
 } from "../helpers/constants.js";
+import { makeLanderExplosion } from "./explosion.js";
+import { makeConfetti } from "./confetti.js";
+import { drawTrajectory } from "./trajectory.js";
 import { drawLanderGradient } from "./gradient.js";
 
 export const makeLander = (state, onGameEnd, onResetXPos) => {

--- a/lander/trajectory.js
+++ b/lander/trajectory.js
@@ -15,7 +15,7 @@ export const drawTrajectory = (
   const CTX = state.get("CTX");
   const canvasWidth = state.get("canvasWidth");
   const canvasHeight = state.get("canvasHeight");
-  const landingData = state.get("terrain").getLandingData();
+  const terrainLandingData = state.get("terrain").getLandingData();
   const scaleFactor = state.get("scaleFactor");
   let projectedXPosition = currentPosition.x;
   let projectedYPosition = currentPosition.y;
@@ -41,7 +41,7 @@ export const drawTrajectory = (
   // Draw the line in two segments: above the max terrainHeight, where we
   // don't have to do any terrain detection; and below the max terrainHeight,
   // where we have to call isPointInPath
-  while (projectedYPosition < landingData.terrainHeight) {
+  while (projectedYPosition < terrainLandingData.terrainHeight) {
     incrementValues();
 
     if (index % 2) {
@@ -52,12 +52,12 @@ export const drawTrajectory = (
 
   // Draw line between max terrain height and actual terrain
   while (
-    projectedYPosition >= landingData.terrainHeight &&
+    projectedYPosition >= terrainLandingData.terrainHeight &&
     projectedYPosition <= canvasHeight &&
     projectedXPosition <= canvasWidth &&
     projectedXPosition >= 0 &&
     !CTX.isPointInPath(
-      landingData.terrainPath2D,
+      terrainLandingData.terrainPath2D,
       projectedXPosition * scaleFactor,
       projectedYPosition * scaleFactor
     )

--- a/lander/trajectory.js
+++ b/lander/trajectory.js
@@ -10,46 +10,67 @@ export const drawTrajectory = (
   currentPosition,
   currentAngle,
   currentVelocity,
-  currentRotationVelocity,
-  groundedHeight
+  currentRotationVelocity
 ) => {
   const CTX = state.get("CTX");
+  const canvasWidth = state.get("canvasWidth");
   const canvasHeight = state.get("canvasHeight");
+  const landingData = state.get("terrain").getLandingData();
+  const scaleFactor = state.get("scaleFactor");
   let projectedXPosition = currentPosition.x;
   let projectedYPosition = currentPosition.y;
   let projectedAngle = currentAngle;
   let projectedYVelocity = currentVelocity.y;
   let index = 0;
 
-  // Start trajectory line
-  CTX.save();
-  CTX.translate(LANDER_WIDTH / 2, LANDER_HEIGHT / 2);
-  CTX.beginPath();
-  CTX.moveTo(
-    projectedXPosition - LANDER_WIDTH / 2,
-    projectedYPosition - LANDER_HEIGHT / 2
-  );
-
-  // Draw line
-  while (projectedYPosition < groundedHeight) {
+  const incrementValues = () => {
     projectedYPosition = Math.min(
       projectedYPosition + projectedYVelocity,
-      groundedHeight
+      canvasHeight
     );
     projectedXPosition += currentVelocity.x;
     projectedAngle += (Math.PI / 180) * currentRotationVelocity;
     projectedYVelocity += GRAVITY;
+  };
+
+  // Start trajectory line
+  CTX.save();
+  CTX.beginPath();
+  CTX.moveTo(projectedXPosition, projectedYPosition);
+
+  // Draw the line in two segments: above the max terrainHeight, where we
+  // don't have to do any terrain detection; and below the max terrainHeight,
+  // where we have to call isPointInPath
+  while (projectedYPosition < landingData.terrainHeight) {
+    incrementValues();
 
     if (index % 2) {
-      CTX.lineTo(
-        projectedXPosition - LANDER_WIDTH / 2,
-        projectedYPosition - LANDER_HEIGHT / 2
-      );
+      CTX.lineTo(projectedXPosition, projectedYPosition);
     }
-
     index++;
   }
 
+  // Draw line between max terrain height and actual terrain
+  while (
+    projectedYPosition >= landingData.terrainHeight &&
+    projectedYPosition <= canvasHeight &&
+    projectedXPosition <= canvasWidth &&
+    projectedXPosition >= 0 &&
+    !CTX.isPointInPath(
+      landingData.terrainPath2D,
+      projectedXPosition * scaleFactor,
+      projectedYPosition * scaleFactor
+    )
+  ) {
+    incrementValues();
+
+    if (index % 2) {
+      CTX.lineTo(projectedXPosition, projectedYPosition);
+    }
+    index++;
+  }
+
+  // Finish trajectory line
   CTX.strokeStyle = "rgb(255, 255, 255, .25)";
   CTX.stroke();
 
@@ -59,11 +80,8 @@ export const drawTrajectory = (
   } else {
     CTX.strokeStyle = "rgb(255, 0, 0)";
   }
-  const arrowSize = Math.min(projectedYVelocity * 4, 20);
-  CTX.translate(
-    projectedXPosition - LANDER_WIDTH / 2,
-    canvasHeight - LANDER_HEIGHT
-  );
+  const arrowSize = Math.max(Math.min(projectedYVelocity * 4, 20), 2);
+  CTX.translate(projectedXPosition, projectedYPosition);
   CTX.rotate(projectedAngle + Math.PI);
   CTX.beginPath();
   CTX.moveTo(0, 0);

--- a/terrain.js
+++ b/terrain.js
@@ -12,9 +12,11 @@ export const makeTerrain = (state) => {
   let landingSurfaces = [];
   let terrain = [];
 
+  // Divide the canvas into three spans with some margin between the spans
+  // and between the spans and the edge of the canvas. This array will be
+  // `pop()`d by `generateLandingSurface()`, so it's shuffled to prevent the
+  // large surface from always being in one region of the screen.
   const generateLandingZonesList = () => {
-    // Divide points into three sections with a little margin between.
-    // Landing zones shouldn't start or end at the edge of the screen.
     landingZones = [
       { minPoint: 1, maxPoint: Math.floor(numPoints / 3) },
       {
@@ -31,15 +33,22 @@ export const makeTerrain = (state) => {
   };
 
   const generateLandingSurface = (widthUnit) => {
+    // Determine how many points are needed to at least be as wide as the
+    // lander, and then use that as a basis for the passed width unit
     const minWidthInPoints = Math.ceil(
       LANDER_WIDTH / (canvasWidth / numPoints)
     );
     const landingZone = landingZones.pop();
     const landingZoneWidth = landingZone.maxPoint - landingZone.minPoint;
+
+    // Ensure the surface is no wider than the zone
     const widthInPoints = Math.min(
       minWidthInPoints * widthUnit,
       landingZoneWidth
     );
+
+    // Only create an offset startPoint if there's enough width to render
+    // the widthInPoints
     const startPoint =
       widthInPoints === landingZoneWidth
         ? landingZone.minPoint
@@ -75,8 +84,6 @@ export const makeTerrain = (state) => {
   };
 
   const reGenerate = () => {
-    // Generate three non-overlapping spans from which
-    // generateLandingSurface pops a value
     generateLandingZonesList();
 
     // One narrow and one wide landing zone

--- a/terrain.js
+++ b/terrain.js
@@ -83,6 +83,7 @@ export const makeTerrain = (state) => {
     return {
       terrainPath2D,
       terrainHeight: maxHeight,
+      terrainMinHeight: minHeight,
       landingSurfaces: landingSurfacesInPixels,
     };
   };

--- a/terrain.js
+++ b/terrain.js
@@ -1,23 +1,108 @@
-import { randomBetween, randomBool } from "./helpers/helpers.js";
+import { randomBetween, shuffleArray } from "./helpers/helpers.js";
+import { LANDER_WIDTH } from "./helpers/constants.js";
 
 export const makeTerrain = (state) => {
   const CTX = state.get("CTX");
   const canvasWidth = state.get("canvasWidth");
   const canvasHeight = state.get("canvasHeight");
-  const maxHeight = 10;
-  const minHeight = 5;
-  const points = Math.max(canvasWidth / 60, 20);
+  const maxHeight = canvasHeight - canvasHeight / 10;
+  const minHeight = canvasHeight - 10;
+  const numPoints = Math.max(canvasWidth / 60, 20);
+  let landingZones = [];
+  let landingSurfaces = [];
   let terrain = [];
 
-  function reGenerate() {
-    terrain = [];
-    for (let index = 1; index < points; index++) {
-      terrain.push({
-        x: index * (canvasWidth / points),
-        y: randomBetween(canvasHeight - minHeight, canvasHeight - maxHeight),
+  const generateLandingZonesList = () => {
+    // Divide points into three sections with a little margin between.
+    // Landing zones shouldn't start or end at the edge of the screen.
+    landingZones = [
+      { minPoint: 1, maxPoint: Math.floor(numPoints / 3) },
+      {
+        minPoint: Math.floor(numPoints / 3) + 1,
+        maxPoint: Math.floor((numPoints / 3) * 2),
+      },
+      {
+        minPoint: Math.floor((numPoints / 3) * 2) + 1,
+        maxPoint: numPoints - 1,
+      },
+    ];
+
+    shuffleArray(landingZones);
+  };
+
+  const generateLandingSurface = (widthUnit) => {
+    const minWidthInPoints = Math.ceil(
+      LANDER_WIDTH / (canvasWidth / numPoints)
+    );
+    const landingZone = landingZones.pop();
+    const landingZoneWidth = landingZone.maxPoint - landingZone.minPoint;
+    const widthInPoints = Math.min(
+      minWidthInPoints * widthUnit,
+      landingZoneWidth
+    );
+    const startPoint =
+      widthInPoints === landingZoneWidth
+        ? landingZone.minPoint
+        : Math.floor(
+            randomBetween(
+              landingZone.minPoint,
+              landingZone.maxPoint - widthInPoints
+            )
+          );
+
+    return {
+      startPoint,
+      widthInPoints,
+      height: randomBetween(minHeight, maxHeight),
+    };
+  };
+
+  const getLandingData = () => {
+    let landingSurfacesInPixels = [];
+
+    landingSurfaces.forEach(({ startPoint, widthInPoints, height }) => {
+      landingSurfacesInPixels.push({
+        x: startPoint * (canvasWidth / numPoints),
+        width: widthInPoints * (canvasWidth / numPoints),
+        height,
       });
+    });
+
+    return {
+      terrainHeight: maxHeight,
+      landingSurfaces: landingSurfacesInPixels,
+    };
+  };
+
+  const reGenerate = () => {
+    // Generate three non-overlapping spans from which
+    // generateLandingSurface pops a value
+    generateLandingZonesList();
+
+    // One narrow and one wide landing zone
+    landingSurfaces = [generateLandingSurface(4), generateLandingSurface(1)];
+    terrain = [];
+
+    for (let index = 1; index < numPoints; index++) {
+      const landingSurface = landingSurfaces.find(
+        (surface) =>
+          index >= surface.startPoint &&
+          index <= surface.startPoint + surface.widthInPoints
+      );
+
+      if (landingSurface) {
+        terrain.push({
+          x: index * (canvasWidth / numPoints),
+          y: landingSurface.height,
+        });
+      } else {
+        terrain.push({
+          x: index * (canvasWidth / numPoints),
+          y: randomBetween(minHeight, maxHeight),
+        });
+      }
     }
-  }
+  };
   reGenerate();
 
   const draw = () => {
@@ -25,16 +110,35 @@ export const makeTerrain = (state) => {
     CTX.fillStyle = "gray";
     CTX.beginPath();
     CTX.moveTo(0, canvasHeight);
-    CTX.lineTo(0, canvasHeight - maxHeight / 2);
+    CTX.lineTo(0, maxHeight);
     terrain.forEach((point) => {
       CTX.lineTo(point.x, point.y);
     });
-    CTX.lineTo(canvasWidth, canvasHeight - maxHeight / 2);
+    CTX.lineTo(canvasWidth, maxHeight);
     CTX.lineTo(canvasWidth, canvasHeight);
     CTX.closePath();
     CTX.fill();
     CTX.restore();
+
+    landingSurfaces.forEach((surfaces) => {
+      CTX.save();
+      CTX.lineWidth = 2;
+      CTX.strokeStyle = "white";
+      CTX.beginPath();
+      CTX.moveTo(
+        surfaces.startPoint * (canvasWidth / numPoints),
+        surfaces.height
+      );
+      CTX.lineTo(
+        surfaces.startPoint * (canvasWidth / numPoints) +
+          surfaces.widthInPoints * (canvasWidth / numPoints),
+        surfaces.height
+      );
+      CTX.closePath();
+      CTX.stroke();
+      CTX.restore();
+    });
   };
 
-  return { draw, reGenerate };
+  return { draw, reGenerate, getLandingData };
 };

--- a/terrain.js
+++ b/terrain.js
@@ -118,10 +118,10 @@ export const makeTerrain = (state) => {
     path.lineTo(canvasWidth, canvasHeight);
     path.closePath();
 
-    return path;
+    terrainPath2D = path;
   };
 
-  terrainPath2D = reGenerate();
+  reGenerate();
 
   const draw = () => {
     CTX.save();

--- a/terrain.js
+++ b/terrain.js
@@ -38,7 +38,7 @@ export const makeTerrain = (state) => {
     // Determine how many points are needed to at least be as wide as the
     // lander, and then use that as a basis for the passed width unit
     const minWidthInPoints = Math.ceil(
-      LANDER_WIDTH / (canvasWidth / numPoints)
+      (LANDER_WIDTH * 1.5) / (canvasWidth / numPoints)
     );
     const landingZone = landingZones.pop();
     const landingZoneWidth = landingZone.maxPoint - landingZone.minPoint;
@@ -72,11 +72,10 @@ export const makeTerrain = (state) => {
   const getLandingData = () => {
     let landingSurfacesInPixels = [];
 
-    landingSurfaces.forEach(({ startPoint, widthInPoints, height }) => {
+    landingSurfaces.forEach(({ startPoint, widthInPoints }) => {
       landingSurfacesInPixels.push({
         x: startPoint * (canvasWidth / numPoints),
         width: widthInPoints * (canvasWidth / numPoints),
-        height,
       });
     });
 

--- a/terrain.js
+++ b/terrain.js
@@ -1,4 +1,4 @@
-import { randomBetween, shuffleArray } from "./helpers/helpers.js";
+import { seededShuffleArray, seededRandomBetween } from "./helpers/helpers.js";
 import { LANDER_WIDTH } from "./helpers/constants.js";
 
 export const makeTerrain = (state) => {
@@ -29,10 +29,12 @@ export const makeTerrain = (state) => {
       },
     ];
 
-    shuffleArray(landingZones);
+    seededShuffleArray(landingZones, state.get("seededRandom"));
   };
 
   const generateLandingSurface = (widthUnit) => {
+    const seededRandom = state.get("seededRandom");
+
     // Determine how many points are needed to at least be as wide as the
     // lander, and then use that as a basis for the passed width unit
     const minWidthInPoints = Math.ceil(
@@ -53,16 +55,17 @@ export const makeTerrain = (state) => {
       widthInPoints === landingZoneWidth
         ? landingZone.minPoint
         : Math.floor(
-            randomBetween(
+            seededRandomBetween(
               landingZone.minPoint,
-              landingZone.maxPoint - widthInPoints
+              landingZone.maxPoint - widthInPoints,
+              seededRandom
             )
           );
 
     return {
       startPoint,
       widthInPoints,
-      height: randomBetween(minHeight, maxHeight),
+      height: seededRandomBetween(minHeight, maxHeight, seededRandom),
     };
   };
 
@@ -105,7 +108,11 @@ export const makeTerrain = (state) => {
       } else {
         terrain.push({
           x: index * (canvasWidth / numPoints),
-          y: randomBetween(minHeight, maxHeight),
+          y: seededRandomBetween(
+            minHeight,
+            maxHeight,
+            state.get("seededRandom")
+          ),
         });
       }
     }

--- a/terrain.js
+++ b/terrain.js
@@ -77,11 +77,11 @@ export const makeTerrain = (state) => {
         x: startPoint * (canvasWidth / numPoints),
         width: widthInPoints * (canvasWidth / numPoints),
         height,
-        terrainPath2D,
       });
     });
 
     return {
+      terrainPath2D,
       terrainHeight: maxHeight,
       landingSurfaces: landingSurfacesInPixels,
     };


### PR DESCRIPTION
* Generate two flat areas to render in the terrain shape: one small and one large
* Store the landing data and terrain shape in state (the shape as a Path2D)
* Use isPointInPath to detect collision with the terrain for debris, confetti, and the lander

To come: incorporate landing area into score