### PR TITLE
Allow lander to fly into space

### DIFF
--- a/bonuspoints.js
+++ b/bonuspoints.js
@@ -1,3 +1,4 @@
+import { LANDER_HEIGHT } from "./helpers/constants.js";
 import {
   clampedProgress,
   transition,
@@ -77,15 +78,17 @@ export const makeBonusPointsManager = (state) => {
     }
   };
 
-  const draw = () => {
+  const draw = (displayOffset) => {
     const timeElapsed = Date.now() - timeOfLastPoint;
 
     if (!hidden && totalPoints > 0 && timeElapsed < timeToShowPointsInMS) {
+      const yPosBasis = displayOffset ? LANDER_HEIGHT * 2 : canvasHeight / 2;
+
       CTX.save();
       CTX.fillStyle = state.get("theme").headlineFontColor;
       CTX.translate(
         canvasWidth / 2,
-        canvasHeight / 2 -
+        yPosBasis -
           transitionInOut(
             -16,
             0,
@@ -131,12 +134,12 @@ export const makeBonusPointsManager = (state) => {
       );
 
       CTX.font = "800 24px/1.5 -apple-system, BlinkMacSystemFont, sans-serif";
-      const textLine1 = `${lastPointLabel} +${lastPointValue}`;
-      CTX.fillText(textLine1, -CTX.measureText(textLine1).width / 2, -16);
+      CTX.textAlign = "center";
+      CTX.fillText(`${lastPointLabel} +${lastPointValue}`, 0, -12);
 
-      CTX.font = "400 24px/1.5 -apple-system, BlinkMacSystemFont, sans-serif";
-      const textLine2 = `${totalPoints} total bonus`;
-      CTX.fillText(textLine2, -CTX.measureText(textLine2).width / 2, 16);
+      CTX.font = "400 16px/1.5 -apple-system, BlinkMacSystemFont, sans-serif";
+      CTX.letterSpacing = "1px";
+      CTX.fillText(`${totalPoints} TOTAL BONUS`, 0, 12);
       CTX.restore();
     }
   };

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -1,6 +1,7 @@
 export const GRAVITY = 0.004;
 export const LANDER_WIDTH = 20;
 export const LANDER_HEIGHT = 40;
+export const TRANSITION_TO_SPACE = LANDER_HEIGHT * 4;
 export const CRASH_VELOCITY = 0.6;
 export const VELOCITY_MULTIPLIER = 20;
 export const CRASH_ANGLE = 11;

--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -122,3 +122,5 @@ export const easeOutBack = (x) => {
 };
 
 export const easeInOutSine = (x) => -(Math.cos(Math.PI * x) - 1) / 2;
+
+export const easeInExpo = (x) => (x === 0 ? 0 : Math.pow(2, 10 * x - 10));

--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ const animationObject = animate((timeSinceStart, deltaTime) => {
   if (instructions.hasClosedInstructions()) {
     landerControls.drawTouchOverlay();
 
-    bonusPointsManager.draw();
+    bonusPointsManager.draw(lander.getPosition().y < TRANSITION_TO_SPACE);
 
     // Move asteroids as lander flies high
     CTX.save();

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import {
   animate,
   clampedProgress,
+  easeInOutSine,
   generateCanvas,
   randomBetween,
   seededRandomBetween,
@@ -107,7 +108,8 @@ const animationObject = animate((timeSinceStart, deltaTime) => {
     transition(
       0,
       maxTerrainOffset,
-      clampedProgress(TRANSITION_TO_SPACE, 0, lander.getPosition().y)
+      clampedProgress(TRANSITION_TO_SPACE, 0, lander.getPosition().y),
+      easeInOutSine
     )
   );
   if (theme.drawBackgroundTerrain) {

--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ const animationObject = animate((timeSinceStart, deltaTime) => {
 
     bonusPointsManager.draw();
 
-    // Move asteroids and confetti as lander flies high
+    // Move asteroids as lander flies high
     CTX.save();
     CTX.translate(
       0,
@@ -136,11 +136,11 @@ const animationObject = animate((timeSinceStart, deltaTime) => {
     if (sendAsteroid && timeSinceStart > asteroidCountdown) {
       asteroids.forEach((a) => a.draw(deltaTime));
     }
+    CTX.restore();
 
     if (randomConfetti.length > 0) {
       randomConfetti.forEach((c) => c.draw(deltaTime));
     }
-    CTX.restore();
 
     lander.draw(timeSinceStart, deltaTime);
   } else {

--- a/index.js
+++ b/index.js
@@ -97,22 +97,7 @@ const animationObject = animate((timeSinceStart, deltaTime) => {
   CTX.fillRect(0, 0, canvasWidth, canvasHeight);
 
   // Move stars in parallax as lander flies high
-  CTX.save();
-  CTX.translate(
-    0,
-    transition(
-      0,
-      canvasHeight,
-      clampedProgress(
-        TRANSITION_TO_SPACE,
-        -canvasHeight * 2,
-        lander.getPosition().y
-      )
-    )
-  );
-  stars.draw();
-  stars.drawStarCurtain(canvasHeight, lander.getVelocity().y);
-  CTX.restore();
+  stars.draw(lander.getVelocity());
 
   // Move terrain as lander flies high
   CTX.save();

--- a/index.js
+++ b/index.js
@@ -108,8 +108,7 @@ const animationObject = animate((timeSinceStart, deltaTime) => {
     transition(
       0,
       maxTerrainOffset,
-      clampedProgress(TRANSITION_TO_SPACE, 0, lander.getPosition().y),
-      easeInOutSine
+      clampedProgress(TRANSITION_TO_SPACE, 0, lander.getPosition().y)
     )
   );
   if (theme.drawBackgroundTerrain) {

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ import { makeStateManager } from "./helpers/state.js";
 import { makeConfetti } from "./lander/confetti.js";
 import { makeTallyManger } from "./tally.js";
 import { makeAsteroid } from "./asteroids.js";
+import { makeSpaceAsteroid } from "./spaceAsteroids.js";
 import { makeChallengeManager } from "./challenge.js";
 import { makeSeededRandom } from "./helpers/seededrandom.js";
 import { makeBonusPointsManager } from "./bonuspoints.js";
@@ -78,6 +79,7 @@ const tally = makeTallyManger();
 let sendAsteroid = seededRandomBool(seededRandom);
 let asteroidCountdown = seededRandomBetween(2000, 15000, seededRandom);
 let asteroids = [makeAsteroid(appState, lander.getPosition, onAsteroidImpact)];
+let spaceAsteroids = [];
 let randomConfetti = [];
 
 // INSTRUCTIONS SHOW/HIDE
@@ -121,6 +123,21 @@ const animationObject = animate((timeSinceStart, deltaTime) => {
     landerControls.drawTouchOverlay();
 
     bonusPointsManager.draw(lander.getPosition().y < TRANSITION_TO_SPACE);
+
+    // Generate and draw space asteroids
+    if (lander.getPosition().y < -canvasHeight * 2) {
+      if (Math.round(randomBetween(0, 100)) === 0) {
+        spaceAsteroids.push(
+          makeSpaceAsteroid(
+            appState,
+            lander.getDisplayPosition,
+            onAsteroidImpact
+          )
+        );
+      }
+
+      spaceAsteroids.forEach((a) => a.draw(deltaTime));
+    }
 
     // Move asteroids as lander flies high
     CTX.save();
@@ -197,6 +214,7 @@ function onResetGame() {
   sendAsteroid = seededRandomBool(seededRandom);
   asteroidCountdown = seededRandomBetween(2000, 15000, seededRandom);
   asteroids = [makeAsteroid(appState, lander.getPosition, onAsteroidImpact)];
+  spaceAsteroids = [];
   bonusPointsManager.reset();
 }
 

--- a/lander/confetti.js
+++ b/lander/confetti.js
@@ -50,7 +50,9 @@ export const makeConfetti = (state, amount, passedPosition, passedVelocity) => {
         jitterCoordinate(_startingVelocity(index)),
         size,
         size,
-        `hsl(${randomBetween(0, 360)}, 100%, 50%)`
+        `hsl(${randomBetween(0, 360)}, 100%, 50%)`,
+        false,
+        false
       );
     });
 
@@ -75,7 +77,8 @@ export const makeConfetti = (state, amount, passedPosition, passedVelocity) => {
         CTX.lineTo(0, size / 2);
         CTX.closePath();
         CTX.fill();
-      }
+      },
+      false
     );
   });
 

--- a/lander/explosion.js
+++ b/lander/explosion.js
@@ -8,7 +8,8 @@ export const makeExplosion = (
   velocity,
   fill,
   size,
-  amount
+  amount,
+  useTerrain = true
 ) => {
   const smallExplosionChunks = new Array(amount)
     .fill()
@@ -19,7 +20,9 @@ export const makeExplosion = (
         jitterCoordinate(velocity),
         randomBetween(size / 4, size),
         randomBetween(size / 4, size),
-        fill
+        fill,
+        false,
+        useTerrain
       )
     );
 

--- a/lander/lander.js
+++ b/lander/lander.js
@@ -565,8 +565,8 @@ export const makeLander = (state, onGameEnd) => {
     } else {
       CTX.save();
       const animateHUDProgress = clampedProgress(
-        0,
-        -canvasHeight / 2,
+        LANDER_HEIGHT,
+        -LANDER_HEIGHT,
         _position.y
       );
       CTX.globalAlpha = transition(0, 1, animateHUDProgress, easeInOutSine);

--- a/lander/lander.js
+++ b/lander/lander.js
@@ -225,7 +225,12 @@ export const makeLander = (state, onGameEnd) => {
         _lastRotation = rotations;
         _lastRotationAngle = _angle;
         _flipConfetti.push(
-          makeConfetti(state, 10, _displayPosition, _velocity)
+          makeConfetti(
+            state,
+            10,
+            _displayPosition,
+            _position.y > 0 ? _velocity : { x: _velocity.x, y: 0 }
+          )
         );
       }
 

--- a/lander/lander.js
+++ b/lander/lander.js
@@ -436,16 +436,13 @@ export const makeLander = (state, onGameEnd) => {
   const _drawLander = () => {
     CTX.save();
 
-    // The lander positions is handled differently in three "altitude zones"
+    // The lander positions is handled differently in two "altitude zones"
     // Zone 1:
     //   The lander is close to the ground - the viewport is static, and the
     //   terrain is visible. The _position is the same as the display position
     // Zone 2:
     //   The lander has transitioned to space, and over the course of two
     //   viewport heights, it's moved linearly to the center of the screen
-    // Zone 3:
-    //   The lander is high above the ground, and it moves between the center
-    //   and the top of the screen; top if it's heading downwards
 
     // Zone 1 positioning
     CTX.translate(
@@ -457,7 +454,7 @@ export const makeLander = (state, onGameEnd) => {
       _position.y < TRANSITION_TO_SPACE ? TRANSITION_TO_SPACE : _position.y;
 
     // Zone 2 positioning
-    if (_position.y < 0 && _position.y > -canvasHeight * 2 && _velocity.y < 0) {
+    if (_position.y < 0) {
       CTX.translate(
         0,
         transition(
@@ -472,29 +469,6 @@ export const makeLander = (state, onGameEnd) => {
         0,
         canvasHeight / 2 - TRANSITION_TO_SPACE,
         clampedProgress(0, -canvasHeight * 2, _position.y),
-        easeInOutSine
-      );
-    }
-
-    // Zone 3 positioning
-    if (_position.y < -canvasHeight * 2) {
-      CTX.translate(0, canvasHeight / 2 - TRANSITION_TO_SPACE);
-      CTX.translate(
-        0,
-        transition(
-          0,
-          -canvasHeight / 2 + TRANSITION_TO_SPACE,
-          clampedProgress(-3, 3, _velocity.y),
-          easeInOutSine
-        )
-      );
-
-      _displayPosition.y += canvasHeight / 2 - TRANSITION_TO_SPACE;
-
-      _displayPosition.y += transition(
-        0,
-        -canvasHeight / 2 + TRANSITION_TO_SPACE,
-        clampedProgress(-3, 3, _velocity.y),
         easeInOutSine
       );
     }

--- a/lander/lander.js
+++ b/lander/lander.js
@@ -238,7 +238,10 @@ export const makeLander = (state, onGameEnd) => {
 
       // Record bonus points for increments of height and speed
       // Ints here are pixels / raw values, not MPH or FT
-      if (_position.y < _heightMilestone - 3500) {
+      if (
+        _position.y <
+        _heightMilestone + Math.min(-3500, _heightMilestone * 3)
+      ) {
         _heightMilestone = _position.y;
         bonusPointsManager.addNamedPoint("newHeight");
       }

--- a/lander/lander.js
+++ b/lander/lander.js
@@ -365,6 +365,19 @@ export const makeLander = (state, onGameEnd) => {
     const yPadding = LANDER_HEIGHT;
     const xPadding = LANDER_HEIGHT;
 
+    const secondsUntilTerrain =
+      _velocity.y > 0
+        ? Math.abs(
+            Math.round(
+              (_position.y -
+                canvasHeight +
+                (canvasHeight - _landingData.terrainAvgHeight)) /
+                _velocity.y /
+                100
+            )
+          )
+        : 99;
+
     CTX.save();
 
     CTX.fillStyle = state.get("theme").infoFontColor;
@@ -389,6 +402,24 @@ export const makeLander = (state, onGameEnd) => {
     CTX.letterSpacing = "1px";
     CTX.font = "400 16px/1.5 -apple-system, BlinkMacSystemFont, sans-serif";
     CTX.fillText("FT", canvasWidth - xPadding, canvasHeight - yPadding);
+
+    if (secondsUntilTerrain < 15) {
+      CTX.fillStyle = "rgb(255, 0, 0)";
+      CTX.textAlign = "center";
+      CTX.font = "600 24px/1.5 -apple-system, BlinkMacSystemFont, sans-serif";
+      CTX.fillText(
+        Intl.NumberFormat().format(secondsUntilTerrain),
+        canvasWidth / 2,
+        canvasHeight - yPadding - 24
+      );
+      CTX.letterSpacing = "1px";
+      CTX.font = "400 16px/1.5 -apple-system, BlinkMacSystemFont, sans-serif";
+      CTX.fillText(
+        "SECONDS UNTIL TERRAIN",
+        canvasWidth / 2,
+        canvasHeight - yPadding
+      );
+    }
 
     CTX.restore();
   };

--- a/lander/lander.js
+++ b/lander/lander.js
@@ -395,7 +395,7 @@ export const makeLander = (state, onGameEnd) => {
     CTX.save();
 
     CTX.fillStyle = state.get("theme").infoFontColor;
-    CTX.font = "600 24px/1.5 -apple-system, BlinkMacSystemFont, sans-serif";
+    CTX.font = "800 24px/1.5 -apple-system, BlinkMacSystemFont, sans-serif";
     CTX.textAlign = "left";
     CTX.fillText(
       `${velocityInMPH(_velocity)}`,
@@ -407,7 +407,7 @@ export const makeLander = (state, onGameEnd) => {
     CTX.fillText("MPH", xPadding, canvasHeight - yPadding);
 
     CTX.textAlign = "right";
-    CTX.font = "600 24px/1.5 -apple-system, BlinkMacSystemFont, sans-serif";
+    CTX.font = "800 24px/1.5 -apple-system, BlinkMacSystemFont, sans-serif";
     CTX.fillText(
       `${heightInFeet(_position.y, _groundedHeight)}`,
       canvasWidth - xPadding,
@@ -420,7 +420,7 @@ export const makeLander = (state, onGameEnd) => {
     if (secondsUntilTerrain < 15) {
       CTX.fillStyle = "rgb(255, 0, 0)";
       CTX.textAlign = "center";
-      CTX.font = "600 24px/1.5 -apple-system, BlinkMacSystemFont, sans-serif";
+      CTX.font = "800 24px/1.5 -apple-system, BlinkMacSystemFont, sans-serif";
       CTX.fillText(
         Intl.NumberFormat().format(secondsUntilTerrain),
         canvasWidth / 2,

--- a/lander/lander.js
+++ b/lander/lander.js
@@ -42,6 +42,7 @@ export const makeLander = (state, onGameEnd) => {
   const _thrust = 0.01;
 
   let _position;
+  let _displayPosition;
   let _velocity;
   let _rotationVelocity;
   let _angle;
@@ -74,6 +75,7 @@ export const makeLander = (state, onGameEnd) => {
       ),
       y: LANDER_HEIGHT * 2,
     };
+    _displayPosition = { ..._position };
     _velocity = {
       x: seededRandomBetween(
         -_thrust * (canvasWidth / 10),
@@ -205,6 +207,8 @@ export const makeLander = (state, onGameEnd) => {
       _angle += deltaTimeMultiplier * ((Math.PI / 180) * _rotationVelocity);
       _velocity.y += deltaTimeMultiplier * GRAVITY;
 
+      _displayPosition.x = _position.x;
+
       if (_engineOn) {
         _velocity.x += deltaTimeMultiplier * (_thrust * Math.sin(_angle));
         _velocity.y -= deltaTimeMultiplier * (_thrust * Math.cos(_angle));
@@ -220,7 +224,9 @@ export const makeLander = (state, onGameEnd) => {
         _rotationCount++;
         _lastRotation = rotations;
         _lastRotationAngle = _angle;
-        _flipConfetti.push(makeConfetti(state, 10, _position, _velocity));
+        _flipConfetti.push(
+          makeConfetti(state, 10, _displayPosition, _velocity)
+        );
       }
 
       // Log new max speed and height
@@ -444,6 +450,9 @@ export const makeLander = (state, onGameEnd) => {
       _position.y < TRANSITION_TO_SPACE ? TRANSITION_TO_SPACE : _position.y
     );
 
+    _displayPosition.y =
+      _position.y < TRANSITION_TO_SPACE ? TRANSITION_TO_SPACE : _position.y;
+
     // Zone 2 positioning
     if (_position.y < 0 && _position.y > -canvasHeight * 2 && _velocity.y < 0) {
       CTX.translate(
@@ -454,6 +463,13 @@ export const makeLander = (state, onGameEnd) => {
           clampedProgress(0, -canvasHeight * 2, _position.y),
           easeInOutSine
         )
+      );
+
+      _displayPosition.y += transition(
+        0,
+        canvasHeight / 2 - TRANSITION_TO_SPACE,
+        clampedProgress(0, -canvasHeight * 2, _position.y),
+        easeInOutSine
       );
     }
 
@@ -468,6 +484,15 @@ export const makeLander = (state, onGameEnd) => {
           clampedProgress(-3, 3, _velocity.y),
           easeInOutSine
         )
+      );
+
+      _displayPosition.y += canvasHeight / 2 - TRANSITION_TO_SPACE;
+
+      _displayPosition.y += transition(
+        0,
+        -canvasHeight / 2 + TRANSITION_TO_SPACE,
+        clampedProgress(-3, 3, _velocity.y),
+        easeInOutSine
       );
     }
 

--- a/lander/lander.js
+++ b/lander/lander.js
@@ -588,6 +588,7 @@ export const makeLander = (state, onGameEnd) => {
     destroy,
     resetProps,
     getPosition: () => _position,
+    getDisplayPosition: () => _displayPosition,
     getVelocity: () => _velocity,
     engineOn: () => (_engineOn = true),
     engineOff: () => (_engineOn = false),

--- a/particle.js
+++ b/particle.js
@@ -16,7 +16,6 @@ export const makeParticle = (
   const terrain = state.get("terrain");
   const landingData = state.get("terrain").getLandingData();
   const friction = 0.3;
-  const velocityThreshold = 2;
   const rotationDirection = randomBool();
 
   let position = { ...startPosition };

--- a/particle.js
+++ b/particle.js
@@ -9,6 +9,7 @@ export const makeParticle = (
   height,
   fill,
   customDraw = false,
+  useTerrain = true,
   onCollide = () => {}
 ) => {
   const CTX = state.get("CTX");
@@ -41,7 +42,7 @@ export const makeParticle = (
       y: position.y + deltaTimeMultiplier * velocity.y,
     };
 
-    if (prospectiveNextPosition.y >= landingData.terrainHeight) {
+    if (useTerrain && prospectiveNextPosition.y >= landingData.terrainHeight) {
       const collisionPoint = isShapeInPath(
         CTX,
         scaleFactor,

--- a/spaceAsteroids.js
+++ b/spaceAsteroids.js
@@ -1,0 +1,101 @@
+import {
+  getVectorVelocity,
+  transition,
+  randomBetween,
+} from "./helpers/helpers.js";
+import { makeExplosion } from "./lander/explosion.js";
+import { LANDER_WIDTH, LANDER_HEIGHT } from "./helpers/constants.js";
+import { makeParticle } from "./particle.js";
+
+export const makeSpaceAsteroid = (
+  state,
+  getLanderPosition,
+  onLanderCollision
+) => {
+  const canvasWidth = state.get("canvasWidth");
+  const canvasHeight = state.get("canvasHeight");
+  const fill = state.get("theme").asteroid;
+  const size = randomBetween(12, 30);
+  let offScreen = false;
+  let startPosition = {
+    x: randomBetween(0, canvasWidth),
+    y: -size,
+  };
+  let startVelocity = {
+    x: randomBetween(-1, 1),
+    y: randomBetween(4, 8),
+  };
+
+  let impact = false;
+
+  const onImpact = (collisionPoint, collisionVelocity) => {
+    impact = makeExplosion(
+      state,
+      collisionPoint,
+      // Slow down velocity to prevent debris from going really high in the air
+      { x: collisionVelocity.x * 0.8, y: collisionVelocity.y * 0.2 },
+      fill,
+      // Smaller pieces for faster impacts (vaporized)
+      // Typical vector velocity range is .5–10
+      transition(15, 3, getVectorVelocity(collisionVelocity) / 10),
+      Math.floor(size),
+      false
+    );
+  };
+
+  const asteroid = makeParticle(
+    state,
+    startPosition,
+    startVelocity,
+    size,
+    size,
+    fill,
+    (CTX, position, _, rotationAngle, fill) => {
+      CTX.fillStyle = fill;
+      CTX.translate(position.x, position.y);
+      CTX.rotate(rotationAngle);
+      CTX.beginPath();
+      CTX.moveTo(-size * 0.5, 0);
+      CTX.lineTo(-size * 0.4, -size * 0.4);
+      CTX.lineTo(0, -size * 0.5);
+      CTX.lineTo(size * 0.4, -size * 0.4);
+      CTX.lineTo(size * 0.5, 0);
+      CTX.lineTo(size * 0.3, size * 0.3);
+      CTX.lineTo(0, size * 0.5);
+      CTX.lineTo(-size * 0.35, size * 0.4);
+      CTX.closePath();
+      CTX.fill();
+    },
+    false
+  );
+
+  const draw = (deltaTime) => {
+    if (!offScreen) {
+      if (asteroid.getPosition().y > canvasHeight + size) {
+        offScreen = true;
+      }
+
+      if (!impact) {
+        const landerPosition = getLanderPosition();
+        const impactXPadding = LANDER_WIDTH;
+        const impactYPadding = LANDER_HEIGHT;
+        const asteroidPosition = asteroid.getPosition();
+        if (
+          asteroidPosition.x > landerPosition.x - impactXPadding &&
+          asteroidPosition.x < landerPosition.x + impactXPadding &&
+          asteroidPosition.y > landerPosition.y - impactYPadding &&
+          asteroidPosition.y < landerPosition.y + impactYPadding
+        ) {
+          onLanderCollision(asteroid.getVelocity());
+          onImpact(asteroidPosition, asteroid.getVelocity());
+        }
+
+        asteroid.draw(deltaTime);
+      } else {
+        impact.draw(deltaTime);
+      }
+    }
+  };
+
+  return { draw };
+};

--- a/starfield.js
+++ b/starfield.js
@@ -1,4 +1,8 @@
-import { randomBetween } from "./helpers/helpers.js";
+import {
+  transition,
+  clampedProgress,
+  randomBetween,
+} from "./helpers/helpers.js";
 
 export const makeStarfield = (state) => {
   const CTX = state.get("CTX");
@@ -11,7 +15,6 @@ export const makeStarfield = (state) => {
     let noiseArray = [];
     for (let index = 0; index < amount; index++) {
       noiseArray.push({
-        size: randomBetween(0.5, 1.5),
         opacity: randomBetween(0.1, 1),
         position: {
           x: Math.random() * canvasWidth,
@@ -20,6 +23,7 @@ export const makeStarfield = (state) => {
             theme.horizon ? theme.horizon * canvasHeight : canvasHeight
           ),
         },
+        distance: Math.random(), // higher number is closer/bigger
       });
     }
     return noiseArray;
@@ -30,32 +34,31 @@ export const makeStarfield = (state) => {
   };
   reGenerate();
 
-  const draw = () => {
-    stars.forEach(({ size, opacity, position }) => {
+  const draw = (velocity) => {
+    stars.forEach(({ distance, opacity, position }) => {
+      position.y =
+        position.y > canvasHeight
+          ? 0
+          : position.y < 0
+          ? canvasHeight
+          : position.y - (velocity.y * distance) / 10;
+
       CTX.save();
       CTX.globalAlpha = opacity;
       CTX.fillStyle = state.get("theme").star;
       CTX.beginPath();
-      CTX.arc(position.x, position.y, size, 0, Math.PI * 2);
+      CTX.arc(
+        position.x,
+        position.y,
+        transition(0.2, 1.5, distance),
+        0,
+        Math.PI * 2
+      );
       CTX.closePath();
       CTX.fill();
       CTX.restore();
     });
   };
 
-  const drawStarCurtain = (verticalOffset, yVelocity) => {
-    stars.forEach(({ size, opacity, position }) => {
-      CTX.save();
-      CTX.translate(0, -verticalOffset);
-      CTX.globalAlpha = opacity;
-      CTX.fillStyle = "red";
-      CTX.beginPath();
-      CTX.arc(position.x, position.y, size, 0, Math.PI * 2);
-      CTX.closePath();
-      CTX.fill();
-      CTX.restore();
-    });
-  };
-
-  return { draw, drawStarCurtain, reGenerate };
+  return { draw, reGenerate };
 };

--- a/starfield.js
+++ b/starfield.js
@@ -43,5 +43,19 @@ export const makeStarfield = (state) => {
     });
   };
 
-  return { draw, reGenerate };
+  const drawStarCurtain = (verticalOffset, yVelocity) => {
+    stars.forEach(({ size, opacity, position }) => {
+      CTX.save();
+      CTX.translate(0, -verticalOffset);
+      CTX.globalAlpha = opacity;
+      CTX.fillStyle = "red";
+      CTX.beginPath();
+      CTX.arc(position.x, position.y, size, 0, Math.PI * 2);
+      CTX.closePath();
+      CTX.fill();
+      CTX.restore();
+    });
+  };
+
+  return { draw, drawStarCurtain, reGenerate };
 };


### PR DESCRIPTION
- [x] Past a position threshold, render the lander in a fixed position and move terrain  and other fixed objects away
- [x] Move the lander around a bit when in a high position to give feecback to controls and to allow the lander to dodge asteroids
  - [x] Transition between this and the close-to-terrain movement/position smoothly
- [x] Once in space, throw asteroids at the lander more frequently
- [x] Render stars in parallax motion, tied to velocity
- [x] Render HUD info more prominently at bottom of screen once lander has left the ground area
  - [x] Show some kind of mini map or clear indicator to help users slow down enough when approaching the planet
- [x] Change the way height records work so it's not popping up all the time

To fix:
- [x] Confetti placement (should it even be a physical object? Or just transient and fade away?)
- [ ] Maybe fix seeded random number generator
- [ ] Check if themes still work and remove if not (stuff like the background elements and horizon, at least)