### PR TITLE
Show time with one decimal point of precision

### DIFF
--- a/lander/lander.js
+++ b/lander/lander.js
@@ -117,7 +117,7 @@ export const makeLander = (state, onGameEnd) => {
         getAngleDeltaUpright(_angle).toFixed(1)
       ),
       durationInSeconds: Intl.NumberFormat().format(
-        Math.round(_timeSinceStart / 1000)
+        (_timeSinceStart / 1000).toFixed(1)
       ),
       rotationsInt: _rotationCount,
       rotationsFormatted: Intl.NumberFormat().format(_rotationCount),


### PR DESCRIPTION
See discussion https://github.com/ehmorris/lunar-lander/discussions/38

I considered having two points of precision, because it's still pretty easy to get the same time within 0.1s, but that would be different to all the other numbers in the game.

![image](https://github.com/user-attachments/assets/2c4ccb80-a94b-4803-aa77-beba66370408)
