### PR TITLE
Fixes for several bugs

### DIFF
--- a/bonuspoints.js
+++ b/bonuspoints.js
@@ -42,6 +42,15 @@ export const makeBonusPointsManager = (state) => {
     timeOfLastPoint = Date.now();
   };
 
+  const addNamedPoints = (name, countOfNamedPoints) => {
+    const totalPointsToAdd = namePointMapping.get(name) * countOfNamedPoints;
+
+    totalPoints += totalPointsToAdd;
+    lastPointValue = totalPointsToAdd;
+    lastPointLabel = nameLabelMapping.get(name);
+    timeOfLastPoint = Date.now();
+  };
+
   const reset = () => {
     timeOfLastPoint = 0;
     totalPoints = 0;
@@ -149,6 +158,7 @@ export const makeBonusPointsManager = (state) => {
     reset,
     getPointValue,
     addNamedPoint,
+    addNamedPoints,
     getTotalPoints: () => totalPoints,
     hide: () => (hidden = true),
   };

--- a/lander/lander.js
+++ b/lander/lander.js
@@ -206,13 +206,13 @@ export const makeLander = (state, onGameEnd) => {
     _position.y = _position.y + deltaTimeMultiplier * _velocity.y;
 
     if (
-      _position.y + LANDER_HEIGHT / 2 < _landingData.terrainHeight ||
-      (_position.y + LANDER_HEIGHT / 2 >= _landingData.terrainHeight &&
-        !CTX.isPointInPath(
-          _landingData.terrainPath2D,
-          _position.x * state.get("scaleFactor"),
-          (_position.y + LANDER_HEIGHT / 2) * state.get("scaleFactor")
-        ))
+      // Lander not currently colliding with terrain and is not underground
+      !CTX.isPointInPath(
+        _landingData.terrainPath2D,
+        _position.x * state.get("scaleFactor"),
+        (_position.y + LANDER_HEIGHT / 2) * state.get("scaleFactor")
+      )
+      && _position.y < canvasHeight
     ) {
       // Update ballistic properties
       if (_rotatingRight) _rotationVelocity += deltaTimeMultiplier * 0.01;

--- a/lander/lander.js
+++ b/lander/lander.js
@@ -205,26 +205,27 @@ export const makeLander = (state, onGameEnd) => {
 
     _position.y = _position.y + deltaTimeMultiplier * _velocity.y;
 
-    if (
-      // Lander not currently colliding with terrain and is not underground
-      !CTX.isPointInPath(
-        _landingData.terrainPath2D,
-        _position.x * state.get("scaleFactor"),
-        (_position.y + LANDER_HEIGHT / 2) * state.get("scaleFactor")
-      )
-      && _position.y < canvasHeight
-    ) {
+    const landerInTerrain = CTX.isPointInPath(
+      _landingData.terrainPath2D,
+      _position.x * state.get("scaleFactor"),
+      (_position.y + LANDER_HEIGHT / 2) * state.get("scaleFactor")
+    );
+
+    const landerUnderTerrain = _position.y >= canvasHeight;
+
+    if (!landerInTerrain && !landerUnderTerrain) {
       // Update ballistic properties
       if (_rotatingRight) _rotationVelocity += deltaTimeMultiplier * 0.01;
       if (_rotatingLeft) _rotationVelocity -= deltaTimeMultiplier * 0.01;
-
 
       _position.x += deltaTimeMultiplier * _velocity.x;
       _angle += deltaTimeMultiplier * ((Math.PI / 180) * _rotationVelocity);
       _velocity.y += deltaTimeMultiplier * GRAVITY;
 
       // Wrap around horizontally if lander moved off screen
-      _position.x = (_position.x - canvasWidth * Math.floor(_position.x / canvasWidth)) % canvasWidth;
+      _position.x =
+        (_position.x - canvasWidth * Math.floor(_position.x / canvasWidth)) %
+        canvasWidth;
 
       _displayPosition.x = _position.x;
 
@@ -237,7 +238,7 @@ export const makeLander = (state, onGameEnd) => {
       const rotations = Math.floor(_angle / (Math.PI * 2));
       if (
         Math.abs(_angle - _lastRotationAngle) > Math.PI * 2 &&
-        (rotations != _lastRotation)
+        rotations != _lastRotation
       ) {
         while (rotations != _lastRotation) {
           bonusPointsManager.addNamedPoint("newRotation");
@@ -253,7 +254,6 @@ export const makeLander = (state, onGameEnd) => {
             _position.y > 0 ? _velocity : { x: _velocity.x, y: 0 }
           )
         );
-
       }
 
       // Log new max speed and height
@@ -400,9 +400,15 @@ export const makeLander = (state, onGameEnd) => {
   const _drawBottomHUD = () => {
     const yPadding = LANDER_HEIGHT;
     const xPadding = LANDER_HEIGHT;
-    const secondsUntilTerrain = _velocity.y > 0 ?
-      (Math.sqrt(_velocity.y ** 2 + 2 * GRAVITY * (_landingData.terrainAvgHeight - _position.y)) - _velocity.y) / (1000 / INTERVAL * GRAVITY)
-      : 99;
+    const secondsUntilTerrain =
+      _velocity.y > 0
+        ? (Math.sqrt(
+            _velocity.y ** 2 +
+              2 * GRAVITY * (_landingData.terrainAvgHeight - _position.y)
+          ) -
+            _velocity.y) /
+          ((1000 / INTERVAL) * GRAVITY)
+        : 99;
     CTX.save();
 
     CTX.fillStyle = state.get("theme").infoFontColor;

--- a/lander/lander.js
+++ b/lander/lander.js
@@ -218,13 +218,13 @@ export const makeLander = (state, onGameEnd) => {
       if (_rotatingRight) _rotationVelocity += deltaTimeMultiplier * 0.01;
       if (_rotatingLeft) _rotationVelocity -= deltaTimeMultiplier * 0.01;
 
-      if (_position.x < 0) _position.x = canvasWidth;
-
-      if (_position.x > canvasWidth) _position.x = 0;
 
       _position.x += deltaTimeMultiplier * _velocity.x;
       _angle += deltaTimeMultiplier * ((Math.PI / 180) * _rotationVelocity);
       _velocity.y += deltaTimeMultiplier * GRAVITY;
+
+      // Wrap around horizontally if lander moved off screen
+      _position.x = (_position.x - canvasWidth * Math.floor(_position.x / canvasWidth)) % canvasWidth;
 
       _displayPosition.x = _position.x;
 

--- a/lander/lander.js
+++ b/lander/lander.js
@@ -237,12 +237,14 @@ export const makeLander = (state, onGameEnd) => {
       const rotations = Math.floor(_angle / (Math.PI * 2));
       if (
         Math.abs(_angle - _lastRotationAngle) > Math.PI * 2 &&
-        (rotations > _lastRotation || rotations < _lastRotation)
+        (rotations != _lastRotation)
       ) {
-        bonusPointsManager.addNamedPoint("newRotation");
-        _rotationCount++;
-        _lastRotation = rotations;
-        _lastRotationAngle = _angle;
+        while (rotations != _lastRotation) {
+          bonusPointsManager.addNamedPoint("newRotation");
+          _rotationCount++;
+          _lastRotation += Math.sign(rotations - _lastRotation);
+          _lastRotationAngle = _angle;
+        }
         _flipConfetti.push(
           makeConfetti(
             state,
@@ -251,6 +253,7 @@ export const makeLander = (state, onGameEnd) => {
             _position.y > 0 ? _velocity : { x: _velocity.x, y: 0 }
           )
         );
+
       }
 
       // Log new max speed and height

--- a/lander/lander.js
+++ b/lander/lander.js
@@ -397,20 +397,9 @@ export const makeLander = (state, onGameEnd) => {
   const _drawBottomHUD = () => {
     const yPadding = LANDER_HEIGHT;
     const xPadding = LANDER_HEIGHT;
-
-    const secondsUntilTerrain =
-      _velocity.y > 0
-        ? Math.abs(
-            Math.round(
-              (_position.y -
-                canvasHeight +
-                (canvasHeight - _landingData.terrainAvgHeight)) /
-                _velocity.y /
-                100
-            )
-          )
-        : 99;
-
+    const secondsUntilTerrain = _velocity.y > 0 ?
+      (Math.sqrt(_velocity.y ** 2 + 2 * GRAVITY * (_landingData.terrainAvgHeight - _position.y)) - _velocity.y) / (1000 / INTERVAL * GRAVITY)
+      : 99;
     CTX.save();
 
     CTX.fillStyle = state.get("theme").infoFontColor;
@@ -436,12 +425,12 @@ export const makeLander = (state, onGameEnd) => {
     CTX.font = "400 16px/1.5 -apple-system, BlinkMacSystemFont, sans-serif";
     CTX.fillText("FT", canvasWidth - xPadding, canvasHeight - yPadding);
 
-    if (secondsUntilTerrain < 15) {
+    if (secondsUntilTerrain < 30) {
       CTX.fillStyle = "rgb(255, 0, 0)";
       CTX.textAlign = "center";
       CTX.font = "800 24px/1.5 -apple-system, BlinkMacSystemFont, sans-serif";
       CTX.fillText(
-        Intl.NumberFormat().format(secondsUntilTerrain),
+        Math.floor(secondsUntilTerrain),
         canvasWidth / 2,
         canvasHeight - yPadding - 24
       );

--- a/lander/lander.js
+++ b/lander/lander.js
@@ -219,9 +219,9 @@ export const makeLander = (state, onGameEnd) => {
       if (_rotatingLeft) _rotationVelocity -= deltaTimeMultiplier * 0.01;
 
       _position.x += deltaTimeMultiplier * _velocity.x;
+      _position.x = ((_position.x % canvasWidth) + canvasWidth) % canvasWidth; // wrap around
       _angle += deltaTimeMultiplier * ((Math.PI / 180) * _rotationVelocity);
       _velocity.y += deltaTimeMultiplier * GRAVITY;
-      _position.x = ((_position.x % canvasWidth) + canvasWidth) % canvasWidth;
       _displayPosition.x = _position.x;
 
       if (_engineOn) {


### PR DESCRIPTION
This PR fixes four minor bugs:
- The lander only checks for collision with the ground surface itself, not whether it's below the ground. This means it can clip through the ground and disappear without crashing at very high speeds.
- The "seconds until terrain" value displayed doesn't take into account acceleration from gravity and is thus very inaccurate.
- The lander resets its position to zero when wrapping around horizontally, and the wraparound is applied before updating the position. This causes problematic behavior like the lander appearing to not move horizontally and disappearing at high horizontal speeds.
- When multiple full rotations are performed in a single frame, only one rotation bonus is given.

I also increased the maximum value that displays the "seconds until terrain" warning from 15 to 30 since the improved accuracy makes it more useful.