### PR TITLE
Remove focus from the selector when changing worlds

### DIFF
--- a/index.js
+++ b/index.js
@@ -255,6 +255,8 @@ function onWorldChange(e) {
   const selectedWorldName = e.target.value;
   if (selectedWorldName === appState.get("worldName")) return;
 
+  worldSelectElement.blur();
+  
   appState.set("worldName", selectedWorldName);
   appState.set("world", getWorldConfig(selectedWorldName));
   appState.set("theme", makeTheme(appState));


### PR DESCRIPTION
Currently after changing worlds, the selector stays focused so pressing the up and down arrows keeps changing worlds.