### PR TITLE
Detect the one-burn hoverslam landing and count engine starts

### DIFF
--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -6,3 +6,14 @@ export const CRASH_VELOCITY = 0.6;
 export const VELOCITY_MULTIPLIER = 20;
 export const CRASH_ANGLE = 11;
 export const INTERVAL = Math.floor(1000 / 120);
+
+// How much longer the player could have coasted before the engine had to come
+// on, and still be credited with a hoverslam. 0 would mean the burn started at
+// the exact last survivable instant.
+export const HOVERSLAM_SLACK_MS = 500;
+
+// A hoverslam means holding the engine all the way into the ground, but judging
+// that to the frame would deny the badge to a finger that came up 8ms early —
+// and the player would have no way to tell why. This is below the threshold of
+// what anyone would perceive as letting go early.
+export const HOVERSLAM_RELEASE_GRACE_MS = 100;

--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -160,6 +160,45 @@ export const seededRandomBool = (seededRandom, probability = 0.5) =>
 export const getVectorVelocity = (velocity) =>
   Math.sqrt(Math.pow(velocity.x, 2) + Math.pow(velocity.y, 2));
 
+// How many more frames the lander could have kept falling before a full-thrust
+// burn became the last thing that could still bring it in under safeSpeed.
+//
+// Distance needed to shed the excess speed is (v² - safeSpeed²) / 2a, so the
+// burn is mandatory the instant altitude equals that. Solving
+// altitude(t) === stoppingDistance(speed(t)) for t collapses to
+// gravity*t² + 2*descentSpeed*t - k = 0.
+//
+// Everything is in the game's native px-per-INTERVAL units, matching the
+// secondsUntilTerrain math in the lander's bottom HUD. Returns 0 when the burn
+// is mandatory right now, negative when the window has already closed (which is
+// reachable — ground level is approximated by the average terrain height, so a
+// low patch of terrain buys real margin), and Infinity when no burn is needed.
+export const framesOfBurnSlack = ({
+  altitude,
+  descentSpeed,
+  safeSpeed,
+  thrust,
+  gravity,
+}) => {
+  const netDeceleration = thrust - gravity;
+  if (netDeceleration <= 0) return -Infinity;
+
+  // Already slow enough to touch down safely, so this isn't a burn that saved
+  // anything. Also catches a lander that's rising rather than falling.
+  if (descentSpeed <= safeSpeed) return Infinity;
+
+  const stoppingDistance =
+    (Math.pow(descentSpeed, 2) - Math.pow(safeSpeed, 2)) /
+    (2 * netDeceleration);
+  const spareDistance = altitude - stoppingDistance;
+  const k = (2 * netDeceleration * spareDistance) / thrust;
+  const discriminant = Math.pow(descentSpeed, 2) + gravity * k;
+
+  if (discriminant < 0) return -Infinity;
+
+  return (Math.sqrt(discriminant) - descentSpeed) / gravity;
+};
+
 export const getAngleDeltaUpright = (angle) => {
   const angleInDeg = (angle * 180) / Math.PI;
   const repeatingAngle = Math.abs(angleInDeg) % 360;

--- a/helpers/scoring.js
+++ b/helpers/scoring.js
@@ -2,6 +2,7 @@ import {
   CRASH_VELOCITY,
   CRASH_ANGLE,
   VELOCITY_MULTIPLIER,
+  HOVERSLAM_SLACK_MS,
 } from "./constants.js";
 import { progress } from "./helpers.js";
 
@@ -70,6 +71,38 @@ export const crashScoreDescription = (score) =>
     : score < 0
     ? "You have to land on the white landing zones"
     : "So, so close to a landing, but still a crash";
+
+// A hoverslam: coast to the last survivable moment, then a single burn held all
+// the way into the ground.
+//
+// Thrust is 3.4x gravity, so the single activation and the hold to touchdown do
+// most of the filtering on their own — igniting early means arresting the fall
+// above the ground and climbing away, which can only then be landed by letting
+// go. Nor can it be faked by descending tilted, since hovering needs ~73° off
+// upright and CRASH_ANGLE is 11. The slack bound is mostly there to close that
+// tilted-descent gap.
+//
+// burnSlackMs is null when the engine was never started, Infinity when no burn
+// was ever needed, and can be negative when a low patch of terrain bought margin
+// the average-height estimate didn't account for.
+export const isHoverslam = ({
+  landed,
+  struckByAsteroid,
+  engineActivations,
+  engineHeldToTouchdown,
+  burnSlackMs,
+}) =>
+  !!landed &&
+  !struckByAsteroid &&
+  engineActivations === 1 &&
+  !!engineHeldToTouchdown &&
+  burnSlackMs !== null &&
+  burnSlackMs <= HOVERSLAM_SLACK_MS;
+
+// Shown in place of the score copy when the landing was earned this way. The
+// engine has no throttle and no fuel limit, so every successful hoverslam is the
+// same maneuver — there are no degrees of it worth different copy.
+export const hoverslamDescription = "Hoverslam!";
 
 export const destroyedDescription = () => {
   const remarks = [

--- a/index.html
+++ b/index.html
@@ -92,6 +92,10 @@
           <span class="tableLabel">Max Height</span>
           <span class="tableValue"><span id="maxHeight"></span> FT</span>
         </div>
+        <div class="tableRow">
+          <span class="tableLabel">Engine Starts</span>
+          <span class="tableValue" id="engineActivations"></span>
+        </div>
       </div>
       <div class="buttonContainer">
         <div class="button loading" id="tryAgain" role="button" tabindex="0" data-dd-action-name="Again">

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ import {
   landingScoreDescription,
   crashScoreDescription,
   destroyedDescription,
+  hoverslamDescription,
 } from "./helpers/scoring.js";
 
 // SETUP
@@ -194,7 +195,9 @@ function onGameEnd(data) {
 
   const finalScore = data.landerScore + bonusPointsManager.getTotalPoints();
   const scoreDescription = data.landed
-    ? landingScoreDescription(finalScore)
+    ? data.hoverslam
+      ? hoverslamDescription
+      : landingScoreDescription(finalScore)
     : data.struckByAsteroid
     ? destroyedDescription()
     : crashScoreDescription(finalScore);

--- a/lander/controls.js
+++ b/lander/controls.js
@@ -3,7 +3,12 @@ export const makeControls = (state, lander, audioManager) => {
   const canvasWidth = state.get("canvasWidth");
   const canvasHeight = state.get("canvasHeight");
   const canvasElement = state.get("canvasElement");
-  const allActiveTouches = new Set();
+  // Which zone each active touch currently occupies, keyed by Touch.identifier.
+  // Zones are reference counted off this map: a second finger landing in a
+  // column must not re-trigger the control, and lifting one of two fingers in
+  // the same column must not release it. Without the count, holding the center
+  // column with two fingers and lifting either one cut the engine mid-burn.
+  const activeTouchZones = new Map();
   const touchColumnMap = ["left", "center", "center", "right"];
 
   let showCenterOverlay = false;
@@ -95,6 +100,27 @@ export const makeControls = (state, lander, audioManager) => {
     return touchColumnMap[clampedColumnNumber];
   };
 
+  const zoneTouchCount = (zoneName) => {
+    let count = 0;
+    activeTouchZones.forEach((zone) => {
+      if (zone === zoneName) count++;
+    });
+    return count;
+  };
+
+  const enterTouchZone = (identifier, zoneName) => {
+    activeTouchZones.set(identifier, zoneName);
+    if (zoneTouchCount(zoneName) === 1) activateTouchZone(zoneName);
+  };
+
+  const leaveTouchZone = (identifier) => {
+    const zoneName = activeTouchZones.get(identifier);
+    if (zoneName === undefined) return;
+
+    activeTouchZones.delete(identifier);
+    if (zoneTouchCount(zoneName) === 0) deactivateTouchZone(zoneName);
+  };
+
   const getColumnBoundary = (colName) => {
     const start =
       touchColumnMap.findIndex((e) => e === colName) / touchColumnMap.length;
@@ -110,8 +136,8 @@ export const makeControls = (state, lander, audioManager) => {
 
   function onTouchStart(e) {
     for (let index = 0; index < e.changedTouches.length; index++) {
-      activateTouchZone(getTouchZone(e.changedTouches[index].clientX));
-      allActiveTouches.add(e.changedTouches[index]);
+      const touch = e.changedTouches[index];
+      enterTouchZone(touch.identifier, getTouchZone(touch.clientX));
     }
 
     if (e.cancelable) e.preventDefault();
@@ -119,37 +145,28 @@ export const makeControls = (state, lander, audioManager) => {
 
   function onTouchMove(e) {
     for (let index = 0; index < e.changedTouches.length; index++) {
-      let touchPreviousData;
-      allActiveTouches.forEach((touch) => {
-        if (touch.identifier === e.changedTouches[index].identifier) {
-          touchPreviousData = touch;
-        }
-      });
-      if (!touchPreviousData) continue;
+      const touch = e.changedTouches[index];
+      const previousZone = activeTouchZones.get(touch.identifier);
+      if (previousZone === undefined) continue;
 
-      const previousTouchZone = getTouchZone(touchPreviousData.clientX);
-      const currentTouchZone = getTouchZone(e.changedTouches[index].clientX);
+      // Two of the four columns are both "center", so sliding between them
+      // reads as the same zone and leaves the engine alone
+      const currentZone = getTouchZone(touch.clientX);
+      if (previousZone === currentZone) continue;
 
-      if (previousTouchZone !== currentTouchZone) {
-        deactivateTouchZone(previousTouchZone);
-        activateTouchZone(currentTouchZone);
-        allActiveTouches.delete(touchPreviousData);
-        allActiveTouches.add(e.changedTouches[index]);
-      }
+      leaveTouchZone(touch.identifier);
+      enterTouchZone(touch.identifier, currentZone);
     }
 
     if (e.cancelable) e.preventDefault();
   }
 
+  // Released zones come from the tracked map rather than from the touch's final
+  // coordinates, so a control can't be left stuck on by a touchend that reports
+  // a position in a different column than the one the finger was holding.
   function onTouchEnd(e) {
     for (let index = 0; index < e.changedTouches.length; index++) {
-      deactivateTouchZone(getTouchZone(e.changedTouches[index].clientX));
-
-      allActiveTouches.forEach((touch) => {
-        if (touch.identifier === e.changedTouches[index].identifier) {
-          allActiveTouches.delete(touch);
-        }
-      });
+      leaveTouchZone(e.changedTouches[index].identifier);
     }
 
     if (e.cancelable) e.preventDefault();
@@ -161,6 +178,9 @@ export const makeControls = (state, lander, audioManager) => {
     canvasElement.addEventListener("touchstart", onTouchStart);
     canvasElement.addEventListener("touchmove", onTouchMove);
     canvasElement.addEventListener("touchend", onTouchEnd);
+    // A touch the browser takes away — a system gesture, an incoming call —
+    // never gets its touchend, and without this its zone stayed held down
+    canvasElement.addEventListener("touchcancel", onTouchEnd);
   };
 
   const detachEventListeners = () => {
@@ -169,12 +189,13 @@ export const makeControls = (state, lander, audioManager) => {
     canvasElement.removeEventListener("touchstart", onTouchStart);
     canvasElement.removeEventListener("touchmove", onTouchMove);
     canvasElement.removeEventListener("touchend", onTouchEnd);
+    canvasElement.removeEventListener("touchcancel", onTouchEnd);
 
     // Whatever the player was holding when the listeners went away can never
     // receive its matching keyup or touchend, so release all three zones.
     // Otherwise crashing mid-thrust leaves the engine sound looping into the
     // next round and the touch column tinted for the rest of the session.
-    allActiveTouches.clear();
+    activeTouchZones.clear();
     deactivateTouchZone("left");
     deactivateTouchZone("center");
     deactivateTouchZone("right");

--- a/lander/lander.js
+++ b/lander/lander.js
@@ -9,8 +9,13 @@ import {
   heightInFeet,
   percentProgress,
   formatDuration,
+  framesOfBurnSlack,
 } from "../helpers/helpers.js";
-import { scoreLanding, scoreCrash } from "../helpers/scoring.js";
+import {
+  scoreLanding,
+  scoreCrash,
+  isHoverslam,
+} from "../helpers/scoring.js";
 import {
   GRAVITY,
   LANDER_WIDTH,
@@ -19,6 +24,7 @@ import {
   CRASH_ANGLE,
   INTERVAL,
   TRANSITION_TO_SPACE,
+  HOVERSLAM_RELEASE_GRACE_MS,
 } from "../helpers/constants.js";
 import { makeLanderExplosion } from "./explosion.js";
 import { makeConfetti } from "./confetti.js";
@@ -65,6 +71,10 @@ export const makeLander = (state, onGameEnd) => {
   let _maxHeight;
   let _heightMilestone;
   let _babySoundPlayed;
+  let _engineActivations;
+  let _firstBurnSlackFrames;
+  let _engineOffAt;
+  let _engineHeldToTouchdown;
 
   const resetProps = () => {
     const seededRandom = state.get("seededRandom").getStream("lander");
@@ -106,12 +116,41 @@ export const makeLander = (state, onGameEnd) => {
     _maxHeight = _position.y;
     _heightMilestone = 0;
     _babySoundPlayed = false;
+    _engineActivations = 0;
+    _firstBurnSlackFrames = null;
+    _engineOffAt = null;
+    _engineHeldToTouchdown = false;
   };
   resetProps();
 
   const _isFixedPositionInSpace = () => _position.y < 0;
 
+  // How much longer the player could have coasted at this instant before the
+  // engine had to come on. Sampled when the engine is first started, to judge
+  // whether the burn was left as late as a hoverslam demands.
+  const _burnSlackFrames = () => {
+    // Thrust points along the lander's axis, so sideways drift can't be shed on
+    // the way down — it eats into the survivable touchdown speed budget
+    const safeSpeed = Math.sqrt(
+      Math.max(0, Math.pow(CRASH_VELOCITY, 2) - Math.pow(_velocity.x, 2))
+    );
+
+    return framesOfBurnSlack({
+      altitude: _groundedHeight - _position.y,
+      descentSpeed: _velocity.y,
+      safeSpeed,
+      thrust: _thrust,
+      gravity: GRAVITY,
+    });
+  };
+
   const _setGameEndData = (landed, struckByAsteroid = false) => {
+    // Infinity means no burn was ever needed, -Infinity that the window was
+    // hopelessly closed. Neither is meaningful to display, but both still
+    // compare correctly against the slack bound in isHoverslam.
+    const burnSlackMs =
+      _firstBurnSlackFrames === null ? null : _firstBurnSlackFrames * INTERVAL;
+
     gameEndData = {
       landed,
       struckByAsteroid,
@@ -135,6 +174,21 @@ export const makeLander = (state, onGameEnd) => {
         CRASH_ANGLE,
         getAngleDeltaUpright(_angle)
       ),
+      engineActivations: _engineActivations,
+      engineActivationsFormatted: Intl.NumberFormat().format(
+        _engineActivations
+      ),
+      burnSlackMs:
+        burnSlackMs !== null && Number.isFinite(burnSlackMs)
+          ? Math.round(burnSlackMs)
+          : null,
+      hoverslam: isHoverslam({
+        landed,
+        struckByAsteroid,
+        engineActivations: _engineActivations,
+        engineHeldToTouchdown: _engineHeldToTouchdown,
+        burnSlackMs,
+      }),
     };
 
     if (landed) {
@@ -179,6 +233,9 @@ export const makeLander = (state, onGameEnd) => {
         flips: gameEndData.rotationsInt,
         maxSpeed: gameEndData.maxSpeed,
         maxHeight: gameEndData.maxHeight,
+        engineActivations: gameEndData.engineActivations,
+        burnSlackMs: gameEndData.burnSlackMs,
+        hoverslam: gameEndData.hoverslam,
       });
     });
 
@@ -287,6 +344,16 @@ export const makeLander = (state, onGameEnd) => {
         _babySoundPlayed = false;
       }
     } else if (!gameEndData) {
+      // Must be read before the engine is force-cleared just below, which
+      // happens well before _setGameEndData runs. The grace window covers a
+      // finger that lifted a frame or two early. Note this branch and destroy()
+      // both assign _engineOn directly rather than calling engineOff(), so
+      // neither is mistaken for the player releasing.
+      _engineHeldToTouchdown =
+        _engineOn ||
+        (_engineOffAt !== null &&
+          _timeSinceStart - _engineOffAt <= HOVERSLAM_RELEASE_GRACE_MS);
+
       _engineOn = false;
       _rotatingLeft = false;
       _rotatingRight = false;
@@ -629,8 +696,21 @@ export const makeLander = (state, onGameEnd) => {
     getVelocity: () => _velocity,
     activateShield: () => (_shieldActive = true),
     hasShield: () => _shieldActive,
-    engineOn: () => (_engineOn = true),
-    engineOff: () => (_engineOn = false),
+    // Only off→on transitions count as an activation. Keydown has no repeat
+    // guard, and multi-touch or a finger sliding between columns can re-fire the
+    // center zone, so a held engine would otherwise register hundreds of starts.
+    engineOn: () => {
+      if (_engineOn || gameEndData) return;
+      _engineOn = true;
+      if (++_engineActivations === 1) {
+        _firstBurnSlackFrames = _burnSlackFrames();
+      }
+    },
+    engineOff: () => {
+      if (!_engineOn) return;
+      _engineOn = false;
+      _engineOffAt = _timeSinceStart;
+    },
     rotateLeft: () => (_rotatingLeft = true),
     rotateRight: () => (_rotatingRight = true),
     stopLeftRotation: () => (_rotatingLeft = false),

--- a/stats.js
+++ b/stats.js
@@ -26,7 +26,9 @@ https://ehmorris.com/lander/
 
 ${data.speed}mph | ${data.angle}° | ${data.rotationsFormatted} flip${
     data.rotationsInt === 1 ? "" : "s"
-  } | ${data.duration}`;
+  } | ${data.duration} | ${data.engineActivations} burn${
+    data.engineActivations === 1 ? "" : "s"
+  }`;
 
   const hideStats = () => {
     document.querySelector("#endGameStats").classList.remove("show");
@@ -65,6 +67,8 @@ ${data.speed}mph | ${data.angle}° | ${data.rotationsFormatted} flip${
     document.querySelector("#rotations").textContent = data.rotationsFormatted;
     document.querySelector("#maxSpeed").textContent = data.maxSpeed;
     document.querySelector("#maxHeight").textContent = data.maxHeight;
+    document.querySelector("#engineActivations").textContent =
+      data.engineActivationsFormatted;
 
     if (hasKeyboard) {
       document.querySelector("#tryAgainText").textContent =


### PR DESCRIPTION
Some players set themselves a challenge the game had no idea about: coast with the engine off until the last survivable moment, then light it once and hold it all the way into the ground. Pull it off and you got the same "Very nice landing, amazing" as a leisurely hover-down.

Two additions:

- **"Hoverslam!"** replaces the score description when a landing was earned that way.
- **An "Engine Starts" row** in the end-game stats table, shown every round so the one-burn challenge is self-scoring even when the badge doesn't fire. It's also in the share/copy text.

Plus a touch-input fix that this feature made load-bearing — see the last section.

## How detection works

Three gates, all required on a successful non-asteroid landing:

| Gate | Condition | Rejects |
|---|---|---|
| One ignition | `engineActivations === 1` | burn → pause → burn |
| Held to the ground | engine still on at the touchdown frame | one burn, then coasting in on gravity |
| Late enough | burn started near the point of no return | thrusting from the top of the screen |

**The first two do most of the filtering on their own.** Thrust is `0.012` against gravity `0.0035` — 3.4×. Igniting appreciably early arrests the fall *above* the ground and starts climbing, which can then only be landed by letting go. Descending tilted can't fake it either: hovering needs ~73° off upright, and `CRASH_ANGLE` is 11. So the slack bound is mostly there to close that tilted-descent gap.

Slack is reported as **how much longer the player could have kept coasting** — directly comparable to the "SECONDS UNTIL TERRAIN" readout they already fly by, rather than a scale-dependent ratio. `framesOfBurnSlack` solves `altitude(t) === stoppingDistance(speed(t))` for `t`, which collapses to a quadratic, in the same px-per-`INTERVAL` units as the bottom HUD's existing fall-time math. Horizontal speed can't be shed on the way down (thrust points along the lander's axis), so it's subtracted from the survivable touchdown budget.

Two constants in `helpers/constants.js` are the tuning knobs: `HOVERSLAM_SLACK_MS` (500) and `HOVERSLAM_RELEASE_GRACE_MS` (100, so a finger that lifts 8ms early isn't silently denied the badge).

Only one message, not a tiered set: the engine has no throttle and no fuel limit, so every successful hoverslam is the same maneuver.

## Two details worth knowing for future changes

- **Activations count only off→on transitions.** `onKeyDown` has no key-repeat guard, and multi-touch or a finger sliding between columns can re-fire the center zone — a held engine would otherwise register hundreds of starts.
- **Whether the engine was held to touchdown must be captured before `_updateProps` force-clears `_engineOn`**, which happens ~20 lines before `_setGameEndData` runs. Reading it inside `_setGameEndData` would always see `false`.

`engineActivations`, `burnSlackMs` and `hoverslam` also go to the existing RUM `score` action, so the slack bound can be tuned against real play instead of guesswork.

## The touch fix (second commit)

`onTouchEnd` deactivated a zone per ending touch without checking whether another finger was still in it. Hold the center column with two fingers, lift either one, and the engine cut out mid-burn while a finger was still down — and nothing turned it back on, since only touchstart and a zone change re-trigger a zone. `onTouchMove` had the same flaw when sliding one of two fingers out of a shared column.

That was survivable when thrust was just thrust, but it silently breaks the badge: the released-and-unreleasable engine both inflates the engine-start count and fails the held-to-touchdown gate, on a run the player flew correctly.

Now a `Map` tracks which zone each touch identifier occupies, and a zone activates or deactivates only as its occupancy crosses zero. Releases resolve the zone from that map instead of recomputing it from the touch's final coordinates. Also listens for `touchcancel` — a touch the browser takes away never gets a `touchend`, so its zone stayed held down for the rest of the round.

## Verification

The repo has no test framework, so this was checked with throwaway harnesses (not committed) plus the real game in Chromium:

- **Slack math** — zero slack exactly at the stopping distance, `Infinity` when no burn was needed or the lander is rising, monotonic in altitude, and an independent frame-by-frame physics simulation confirming a burn started at the computed point touches down survivably.
- **Gate logic** — full truth table over `isHoverslam`, including `Infinity`/negative/`null` slack and the crash and asteroid paths.
- **The real game** — no JS errors; holding thrust 2s counts as 1 start (the key-repeat guard); three taps count as 3; the counter clears on Play Again; the new RUM fields and share text are populated.
- **The badge screen** — verified end to end by patching the served `lander.js` in flight to force a qualifying landing, confirming `#description` shows `Hoverslam!` and the usual score copy is bypassed.
- **Multi-touch** — real touch events via CDP, asserting exact zone state: two fingers in center and lifting one keeps the engine lit, sliding across the internal center seam doesn't blip it, a zone hands off correctly between columns, three fingers release independently, `touchcancel` releases, and a 40-step random sequence leaves nothing stuck. Run against the pre-fix `controls.js` this suite fails on exactly the three regression assertions, so it isn't vacuous.

One thing I could not automate: flying a genuine hoverslam headlessly would need a full autopilot, since the lander exposes no angle getter and has to come down on a pad. **Worth one manual playtest** — coast to ~100 FT at speed, hold thrust to touchdown without releasing — mainly to sanity-check that `HOVERSLAM_SLACK_MS` feels right in the hand.